### PR TITLE
Support compiler options

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,8 +40,8 @@ function asyncHelpers(handlebars) {
     return _template(spec, handlebars)
   }
 
-  handlebars.compile = function() {
-    const compiled = _compile.apply(handlebars, [...arguments, { noEscape: true }])
+  handlebars.compile = function(template, options) {
+    const compiled = _compile.apply(handlebars, [template, { ...options, noEscape: true }])
 
     return function(context, execOptions) {
       context = context || {}


### PR DESCRIPTION
Passing config options to `compile()` breaks. This uses the two defined arguments accepted by `compile()` and merges with `noEscape` used in code.

Was running into an issue with partials returning an error with `result.split('\n')` not found, needed to pass `preventIndent` to get this library working with partials.