### PR TITLE
fix #11: support nested async values in context

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,10 +52,20 @@ function asyncHelpers(hbs) {
           return _escapeExpression(value)
         }
 
+  function lookupProperty(containerLookupProperty) {
+    return function(parent, propertyName) {
+      if (isPromise(parent)) {
+        return parent.then((p) => containerLookupProperty(p, propertyName))
+      }
+      return containerLookupProperty(parent, propertyName)
+    }
+  }
+
   handlebars.template = function(spec) {
     spec.main_d = (prog, props, container, depth, data, blockParams, depths) => async(context) => {
       // const main = await spec.main
       container.escapeExpression = escapeExpression
+      container.lookupProperty = lookupProperty(container.lookupProperty)
       const v = spec.main(container, context, container.helpers, container.partials, data, blockParams, depths)
       return v
     }

--- a/test/test.js
+++ b/test/test.js
@@ -70,6 +70,32 @@ describe('Test async helpers', () => {
 
     })
 
+    it ('Test lookupProperty', async() => {
+        const hbs = asyncHelpers(Handlebars),
+            template = `{{person.[0].firstName}}`,
+            expected = 'John'
+        const compiled = hbs.compile(template),
+            result = await compiled({
+                person: [
+                    Promise.resolve({firstName: 'John', lastName: 'Q'}),
+                ]
+            })
+        should.equal(result, expected)
+    })
+
+    it ('Test lookupProperty with nested promises', async() => {
+        const hbs = asyncHelpers(Handlebars),
+            template = `{{person.[0].firstName}}`,
+            expected = 'John'
+        const compiled = hbs.compile(template),
+            result = await compiled({
+                person: Promise.all([
+                    Promise.resolve({firstName: 'John', lastName: 'Q'}),
+                ])
+            })
+        should.equal(result, expected)
+    })
+
     it('Test with helper', async () => {
         const hbs = asyncHelpers(Handlebars),
             template = `<div class="names">

--- a/test/test.js
+++ b/test/test.js
@@ -70,7 +70,7 @@ describe('Test async helpers', () => {
 
     })
 
-    it ('Test lookupProperty', async() => {
+    it('Test lookupProperty', async() => {
         const hbs = asyncHelpers(Handlebars),
             template = `{{person.[0].firstName}}`,
             expected = 'John'
@@ -83,7 +83,7 @@ describe('Test async helpers', () => {
         should.equal(result, expected)
     })
 
-    it ('Test lookupProperty with nested promises', async() => {
+    it('Test lookupProperty with nested promises', async() => {
         const hbs = asyncHelpers(Handlebars),
             template = `{{person.[0].firstName}}`,
             expected = 'John'


### PR DESCRIPTION
This fixes #11 by enabling support for async values when using nested input objects.