### PR TITLE
Don't use reserved strict word "package"

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Library that adds support to asynchronous function helpers to handlebars lib.
 npm install handlebars-async-helpers
 ```
 
-### Hot wo use it.
+### How to use
 ```javascript
 const handlebars = require('handlebars'),
       asyncHelpers = require('handlebars-async-helpers')

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const package = require('./package.json')
+const app = require('./package.json')
 const { registerCoreHelpers } = require('./helpers')
 
 const isPromise = (obj) => !!obj && (typeof obj === 'object' || typeof obj === 'function') && typeof obj.then === 'function'
@@ -81,7 +81,7 @@ function asyncHelpers(hbs) {
       return compiled.call(handlebars, context, execOptions)
     }
   }
-  handlebars.ASYNC_VERSION = package.version
+  handlebars.ASYNC_VERSION = app.version
 
   registerCoreHelpers(handlebars)
 


### PR DESCRIPTION
This PR renames reserved strict word "package" so that it can be run in strict mode.