### PR TITLE
Fix a problem with indentation

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,8 +79,45 @@ function asyncHelpers(hbs) {
 
     return function(context, execOptions) {
       context = context || {}
+      let indent = false;
+      if (execOptions?.indent) {
+        execOptions.indent = undefined
+        indent = true
+      }
+      const result = compiled.call(handlebars, context, execOptions)
+      if (!indent) {
+        return result
+      } else {
 
-      return compiled.call(handlebars, context, execOptions)
+
+        // this are dummy methods to work with handlebar code, it is only designed for usage with that, otherwise it may break!
+        result.split = () => { return result }
+        result.join = () => { return result }
+        result.length = 0
+
+        // this is a proxy to post process the promise result, it overrides the then method and therefore does the indent split - join job after the result is here!
+        const resultProxy = new Proxy(result, {
+          then(cb) {
+            result.then(res => {
+              if (indent) {
+                const lines = res.split('\n');
+                for (let i = 0, l = lines.length; i < l; i++) {
+                  if (!lines[i] && i + 1 === l) {
+                    break;
+                  }
+
+                  lines[i] = indent + lines[i];
+                }
+                res = lines.join('\n');
+              }
+              return cb(res)
+            })
+          }
+        })
+
+        return resultProxy
+
+      }
     }
   }
   handlebars.ASYNC_VERSION = app.version

--- a/test/test.js
+++ b/test/test.js
@@ -320,6 +320,25 @@ describe('Test async helpers', () => {
         should.equal(result, expected)
     })
 
+    it('Test indentation with async partial', async () => {
+        const hbs = asyncHelpers(Handlebars),
+            template = '<div>Parent {{> child}}</div>',
+            child = '<div>Child:\n\t\t\t{{> grandChild}}</div>',
+            grandChild = '<p>\nGrand Child: {{#delayed 50}}{{/delayed}}\n</p>',
+            expected = '<div>Parent <div>Child:\n\t\t\t<p>\nGrand Child: Hello!\n</p></div></div>'
+        hbs.registerHelper('delayed', (time) => {
+            return new Promise((resolve) => {
+                setTimeout(() => resolve('Hello!'), time)
+            })
+        })
+        hbs.registerPartial('child', child)
+        hbs.registerPartial('grandChild', grandChild)
+        const compiled = hbs.compile(template),
+            result = await compiled()
+        should.equal(result, expected)
+
+    })
+
     it('Test synchronous helper', async () => {
         const hbs = asyncHelpers(Handlebars),
           template = '<div>Value: {{#multiply 100 20}}{{/multiply}}</div>',


### PR DESCRIPTION
I discovered a problem with the `options.indent`:

You receive an error, if you have indentation in some place:

```
./node_modules/handlebars/lib/handlebars/runtime.js:99
        let lines = result.split('\n');
TypeError: result.split is not a function
```

This is due the fact, that result is a Promise and not a string.
To fix this I analyzed the usage of this particular code path and fixed it by using a "tampered" Promise, that has these noop function, but performs the process on the result afterwards, this fixes the problem without modifying handlebar code.

I also added a test, that failed before the fix.